### PR TITLE
Improve load_trained_model script to delete model on failure

### DIFF
--- a/constants.ini
+++ b/constants.ini
@@ -1,12 +1,12 @@
 [DSL]
 
-TRAINING_PUBLIC_RUUTER=http://ruuter:8080
+TRAINING_PUBLIC_RUUTER=http://ruuter:8080/training
 TRAINING_DMAPPER=http://dmapper:3000
 CHATBOT_RUUTER_PRIVATE=http://localhost:8088
 CHATBOT_BOT_RESQL=http://localhost:8082
 TRAINING_OPENSEARCH=http://opensearch:9200
 TRAINING_TIM=http://tim:8085
-TRAINING_RESQL=http://resql:8082
+TRAINING_RESQL=http://resql:8082/training
 TRAINING_USERS_RESQL=http://resql-users:8088
 TRAINING_PIPELINE=http://pipelines:3010
 TRAINING_RASA=http://rasa:5005
@@ -18,6 +18,6 @@ CRON_MANAGER=http://cron-manager:9010
 CHATBOT_BOT=http://rasa:5005
 CHATBOT_PRIVATE_RUUTER=http://ruuter-private:8088
 
-TRAINING_FILES_PATH=/data/DMapper/locations/data/
-TESTING_FILES_PATH=/data/DMapper/locations/tests/
-CROSS_VALIDATION_FILES_PATH=/data/DMapper/locations/data/nlu/
+TRAINING_FILES_PATH=/data/DMapper/training/locations/data/
+TESTING_FILES_PATH=/data/DMapper/training/locations/tests/
+CROSS_VALIDATION_FILES_PATH=/data/DMapper/training/locations/data/nlu/

--- a/scripts/load_trained_model.sh
+++ b/scripts/load_trained_model.sh
@@ -35,6 +35,7 @@ sleep 5
 load_status=$(curl -s -w "%{http_code}" -X PUT -H "Content-Type: application/json" -d '{"model_file":"/app/models/'$filename'"}' "$CHATBOT_BOT/model")
 if [ "$load_status" != "204" ]; then
     echo "error: failed to load trained model from RASA with status code $load_status"
+    rm /data/$filename
     exit 1
 fi
 


### PR DESCRIPTION
Improve `load_trained_model.sh` script to delete model on failure.
This PR is related to issue https://github.com/buerokratt/Training-Module/issues/895